### PR TITLE
use relative source path

### DIFF
--- a/conf.d/based.fish
+++ b/conf.d/based.fish
@@ -1,4 +1,4 @@
 # Load the based logger (for fish_postexec event)
-source ~/.config/fish/functions/__based_log.fish
+source (status dirname)/../functions/__based_log.fish
 # Load keybindings (↑ for smart history, Ctrl+g for fzf popup)
-source ~/.config/fish/functions/based_user_key_bindings.fish
+source (status dirname)/../functions/based_user_key_bindings.fish


### PR DESCRIPTION
 $__fish_config_dir    could be set to something completely different. but using a relative path here is safe either way. This way it can be sourced anywhere, even if the repo is just cloned in some random place.